### PR TITLE
Use correct EC command to fetch keyboard backlight level

### DIFF
--- a/framework_laptop.c
+++ b/framework_laptop.c
@@ -115,13 +115,11 @@ static enum led_brightness kb_led_get(struct led_classdev *led)
 	struct {
 		struct cros_ec_command msg;
 		union {
-			struct ec_params_pwm_get_duty p;
-			struct ec_response_pwm_get_duty resp;
+			struct ec_response_pwm_get_keyboard_backlight resp;
 		};
 	} __packed buf;
 
-	struct ec_params_pwm_get_duty *p = &buf.p;
-	struct ec_response_pwm_get_duty *resp = &buf.resp;
+	struct ec_response_pwm_get_keyboard_backlight *resp = &buf.resp;
 	struct cros_ec_command *msg = &buf.msg;
 	struct cros_ec_device *ec;
 	int ret;
@@ -132,19 +130,17 @@ static enum led_brightness kb_led_get(struct led_classdev *led)
 
 	memset(&buf, 0, sizeof(buf));
 
-	p->pwm_type = EC_PWM_TYPE_KB_LIGHT;
-	
 	msg->version = 0;
-	msg->command = EC_CMD_PWM_GET_DUTY;
+	msg->command = EC_CMD_PWM_GET_KEYBOARD_BACKLIGHT;
 	msg->insize = sizeof(*resp);
-	msg->outsize = sizeof(*p);
+	msg->outsize = 0;
 
 	ret = cros_ec_cmd_xfer_status(ec, msg);
 	if (ret < 0) {
 		goto out;
 	}
 
-	return resp->duty * 100 / EC_PWM_MAX_DUTY;
+	return resp->enabled ? resp->percent : 0;
 
 out:
 	return 0;


### PR DESCRIPTION
The EC has a dedicated command for fetching the backlight level; use that instead of checking PWM duty cycle, which doesn't appear to work (catting the 'brightness' sysfs node always returns 0, regardless of the actual backlight level).

This is also what framework_tool does when passed '--kblight' with no options.